### PR TITLE
Schema suggestions

### DIFF
--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -41,9 +41,10 @@ type Slot {
 }
 
 type TransactionInput {
-  txId: String!,
-  outputIndex: Int!
+  sourceTxId: String!,
+  sourceTxOutputIndex: Int!
   address: String!
+  value: Int!
 }
 
 type TransactionOutput {
@@ -60,7 +61,7 @@ type Transaction {
 }
 
 input TransactionFilter {
-  address: String
+  hashes: [String]
   addresses: [String]
   epoch: Int
   slot: Int
@@ -75,7 +76,7 @@ type Query {
   blocks(ids: [String!], filter: BlockFilter): [Block!]!
   epoch(number: Int) : Epoch!
   epochs(numbers: [Int!]): [Epoch!]!
-  transaction(id: ID!): Transaction
-  transactions(ids: [ID], filter: TransactionFilter): [Transaction]!
+  transaction(hash: String!): Transaction
+  transactions(hashes: [String!], filter: TransactionFilter): [Transaction]!
   utxo(address: String): [TransactionOutput]!
 }


### PR DESCRIPTION
1) For TransactionInput, if we know the address, we also know the value, so I think its worth displaying. I also think its worth being more explicit with the `source` prefix. We can decide on that term.
2) For querying transactions, I think the result should always be an array. So the differentiation between singular and plural seems unnecessary. The same likely goes for the `Query` type, but we can discuss this point first. I assume when you specified address you meant query the transaction that has inputs or outputs for that address? For that reason I also added hash, as this will be the primary way of query transactions
3) The transaction id we see in the DB has not relation to chain. I think we will only ever want to query by hash