### PR TITLE
Enforce range when querying epoch by number

### DIFF
--- a/src/__snapshots__/integration.spec.ts.snap
+++ b/src/__snapshots__/integration.spec.ts.snap
@@ -250,6 +250,27 @@ Object {
 }
 `;
 
+exports[`Integration epochs Returns epoch details by number range 1`] = `
+Object {
+  "data": Object {
+    "epochs": Array [
+      Object {
+        "number": 1,
+        "output": "17282903106017760",
+        "transactionsCount": "5344",
+      },
+    ],
+  },
+  "errors": undefined,
+  "extensions": undefined,
+  "http": Object {
+    "headers": Headers {
+      Symbol(map): Object {},
+    },
+  },
+}
+`;
+
 exports[`Integration transactions Returns transactions by IDs 1`] = `
 Object {
   "data": Object {

--- a/src/integration.spec.ts
+++ b/src/integration.spec.ts
@@ -169,10 +169,55 @@ describe('Integration', () => {
   })
 
   describe('epochs', () => {
+    const noBoundErrorMessage = 'number must be specified (_eq) or bounded (_gte | _gt && _lte | _lt)'
+    const boundTooLargeMessage = 'Maximum number of epochs queryable in a range is 10'
+
+    it('throws if number is not specified in the where clause', async () => {
+      const result = await client.query({
+        query: gql`query {
+            epochs {
+                output
+                number
+                transactionsCount
+            }
+        }`
+      })
+
+      expect(result.errors[0].message).toEqual(noBoundErrorMessage)
+    })
+
+    it('throws if the bound specified in the where clause is too large', async () => {
+      const result = await client.query({
+        query: gql`query {
+            epochs(where: {number: {_in: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]}}) {
+                output
+                number
+                transactionsCount
+            }
+        }`
+      })
+
+      expect(result.errors[0].message).toEqual(boundTooLargeMessage)
+    })
+
     it('Returns epoch details by number', async () => {
       const result = await client.query({
         query: gql`query {
             epochs( where: { number: { _eq: ${epoch1.number} }}) {
+                output
+                number
+                transactionsCount
+            }
+        }`
+      })
+      expect(result.data.epochs[0]).toEqual(epoch1)
+      expect(result).toMatchSnapshot()
+    })
+
+    it('Returns epoch details by number range', async () => {
+      const result = await client.query({
+        query: gql`query {
+            epochs( where: { number: { _in: [${epoch1.number}] }}) {
                 output
                 number
                 transactionsCount

--- a/test/postgres/init/003_views.sql
+++ b/test/postgres/init/003_views.sql
@@ -94,6 +94,7 @@ join tx
   on tx.block = block.id
 join tx_out
   on tx_out.tx_id = tx.id
+where epoch_no is not null
 group by block.epoch_no
 order by block.epoch_no;
 

--- a/test/postgres/init/004_indices.sql
+++ b/test/postgres/init/004_indices.sql
@@ -4,6 +4,9 @@ ON block(slot_no);
 CREATE INDEX idx_block_block_no 
 ON block(block_no);
 
+CREATE INDEX idx_block_epoch_no 
+ON block(epoch_no);
+
 CREATE INDEX idx_block_previous 
 ON block(previous);
 


### PR DESCRIPTION
The test assertions are a vanilla & brittle. Although as this is an integration test, there isn't much else to assert against except the string of the error message.