### PR TITLE
Fix/cannot read networksynchronization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,7 @@ ENV \
   LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH" \
   METADATA_SERVER_URI=${METADATA_SERVER_URI} \
   OGMIOS_HOST="cardano-node-ogmios" \
+  OGMIOS_PORT=1337 \
   POSTGRES_DB_FILE=/run/secrets/postgres_db \
   POSTGRES_HOST=postgres \
   POSTGRES_PASSWORD_FILE=/run/secrets/postgres_password \
@@ -98,7 +99,8 @@ ENV \
   HASURA_URI="http://hasura:8080" \
   LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH" \
   NETWORK=${NETWORK} \
-  OGMIOS_HOST="cardano-node-ogmios"
+  OGMIOS_HOST="cardano-node-ogmios" \
+  OGMIOS_PORT=1337
 COPY --from=cardano-graphql-builder /app/packages/api-cardano-db-hasura/dist /app/packages/api-cardano-db-hasura/dist
 COPY --from=cardano-graphql-builder /app/packages/api-cardano-db-hasura/hasura/project /app/packages/api-cardano-db-hasura/hasura/project
 COPY --from=cardano-graphql-builder /app/packages/api-cardano-db-hasura/package.json /app/packages/api-cardano-db-hasura/package.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
   hasura:
     build:
       context: ./packages/api-cardano-db-hasura/hasura
-    image: cardanofoundation/cardano-graphql-hasura:${CARDANO_GRAPHQL_VERSION:-8.0.1}
+    image: cardanofoundation/cardano-graphql-hasura:${CARDANO_GRAPHQL_VERSION:-8.0.3}
     ports:
       - ${HASURA_PORT:-8090}:8080
     depends_on:
@@ -100,7 +100,7 @@ services:
       cache_from: [ cardanofoundation/cardano-graphql-background:latest ]
       context: .
       target: background
-    image: cardanofoundation/cardano-graphql-background:${CARDANO_GRAPHQL_VERSION:-8.0.1}-${NETWORK:-mainnet}
+    image: cardanofoundation/cardano-graphql-background:${CARDANO_GRAPHQL_VERSION:-8.0.3}-${NETWORK:-mainnet}
     depends_on:
       - "hasura"
       - "postgres"
@@ -126,7 +126,7 @@ services:
       cache_from: [ inputoutput/cardano-graphql-server:latest ]
       context: .
       target: server
-    image: cardanofoundation/cardano-graphql-server:${CARDANO_GRAPHQL_VERSION:-8.0.1}-${NETWORK:-mainnet}
+    image: cardanofoundation/cardano-graphql-server:${CARDANO_GRAPHQL_VERSION:-8.0.3}-${NETWORK:-mainnet}
     environment:
       - ALLOW_INTROSPECTION=true
       - CACHE_ENABLED=true

--- a/packages/api-cardano-db-hasura/src/CardanoNodeClient.ts
+++ b/packages/api-cardano-db-hasura/src/CardanoNodeClient.ts
@@ -61,9 +61,12 @@ export class CardanoNodeClient {
     )
     await pRetry(async () => {
       await this.serverHealthFetcher.initialize()
+      if (this.serverHealthFetcher.value === undefined || this.serverHealthFetcher.value.networkSynchronization === undefined) {
+        throw Error('Ogmios Server Health Fetcher not initialized. Check your network config.')
+      }
     }, {
       factor: 1.2,
-      retries: 3,
+      retries: 100,
       onFailedAttempt: util.onFailedAttemptFor(
         'Establishing connection to Ogmios server',
         this.logger

--- a/packages/api-cardano-db-hasura/src/CardanoNodeClient.ts
+++ b/packages/api-cardano-db-hasura/src/CardanoNodeClient.ts
@@ -57,12 +57,14 @@ export class CardanoNodeClient {
     this.serverHealthFetcher = this.serverHealthFetcher || new DataFetcher(
       'ServerHealth',
       () => getServerHealth({ connection: createConnectionObject(ogmiosConnectionConfig) }),
-      30000, this.logger
+      5000, this.logger
     )
+    await this.serverHealthFetcher.initialize()
     await pRetry(async () => {
-      await this.serverHealthFetcher.initialize()
-      if (this.serverHealthFetcher.value === undefined || this.serverHealthFetcher.value.networkSynchronization === undefined) {
-        throw Error('Ogmios Server Health Fetcher not initialized. Check your network config.')
+      const serverHealth = await getServerHealth({ connection: createConnectionObject(ogmiosConnectionConfig) })
+      this.logger.info(serverHealth)
+      if (serverHealth === undefined) {
+        throw new Error()
       }
     }, {
       factor: 1.2,

--- a/packages/api-cardano-db-hasura/src/CardanoNodeClient.ts
+++ b/packages/api-cardano-db-hasura/src/CardanoNodeClient.ts
@@ -62,7 +62,7 @@ export class CardanoNodeClient {
     await this.serverHealthFetcher.initialize()
     await pRetry(async () => {
       const serverHealth = await getServerHealth({ connection: createConnectionObject(ogmiosConnectionConfig) })
-      this.logger.info(serverHealth)
+      this.logger.info('Waiting for Ogmios Serverhealth to be available')
       if (serverHealth === undefined) {
         throw new Error()
       }

--- a/packages/api-cardano-db-hasura/src/CardanoNodeClient.ts
+++ b/packages/api-cardano-db-hasura/src/CardanoNodeClient.ts
@@ -59,12 +59,12 @@ export class CardanoNodeClient {
       () => getServerHealth({ connection: createConnectionObject(ogmiosConnectionConfig) }),
       5000, this.logger
     )
-    await this.serverHealthFetcher.initialize()
     await pRetry(async () => {
-      const serverHealth = await getServerHealth({ connection: createConnectionObject(ogmiosConnectionConfig) })
-      this.logger.info('Waiting for Ogmios Serverhealth to be available')
-      if (serverHealth === undefined) {
-        throw new Error()
+      try {
+        await this.serverHealthFetcher.initialize()
+      } catch (e) {
+        this.logger.info('Waiting for Ogmios to be ready...')
+        throw e
       }
     }, {
       factor: 1.2,

--- a/packages/util/src/data_fetching/DataFetcher.ts
+++ b/packages/util/src/data_fetching/DataFetcher.ts
@@ -18,7 +18,11 @@ export class DataFetcher<DataValue> {
     this.fetch = async () => {
       if (this.isFetching) return
       this.isFetching = true
-      this.value = await fetchFn()
+      try {
+        this.value = await fetchFn()
+      } catch (e) {
+        this.logger.debug('Tried fetching...')
+      }
       this.isFetching = false
     }
   }


### PR DESCRIPTION
# Context

An error occured when submitting a transaction, which lead to the ogmios ServerStatusHealth check. At application startup the health check throws an error, when the server component is faster in starting as ogmios node. After this error the application couldn't recover, so the serverStatusHealth object was empty leading to an undefined networksynchronization field. 

# Proposed Solution

This PR contains the solution. The error will be catched and this will avoid the crash of Ogmios Serverstatus checker. 
