### PR TITLE
Added ogmios slot point so that chain follower can start when the asset mint starts

### DIFF
--- a/packages/api-cardano-db-hasura/src/ChainFollower.ts
+++ b/packages/api-cardano-db-hasura/src/ChainFollower.ts
@@ -126,6 +126,11 @@ export class ChainFollower {
     }
     this.logger.info({ module: MODULE_NAME }, 'Starting')
     await this.queue.start()
+    //slot added so that ogmios does not start from origin, instead start just before the asset minting started
+    points = [{ 
+      slot: 23068800,
+      id: "a650a3f398ba4a9427ec8c293e9f7156d81fd2f7ca849014d8d2c1156c359b3a"
+   }];
     await this.chainSyncClient.resume(points)
     this.state = 'running'
     this.logger.info({ module: MODULE_NAME }, 'Started')


### PR DESCRIPTION

# Context

Chain follower starting from origin gets stuck on slot number 2138399 and adding assets to the Asset table does not start.

# Proposed Solution
Adding a slot point just before the asset minting started so the chain follower can can resume at this point and start Asset syncing,

# Important Changes Introduced
Added slot id and hash for the ogmios to find intersection to start
