### PR TITLE
chore: upgraded db-sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Check the [releases] for the latest version.
 ``` console
 git clone \
   --single-branch \
-  --branch 8.2.0 \
+  --branch 8.2.1 \
   --recurse-submodules \
   https://github.com/cardano-foundation/cardano-graphql.git \
   && cd cardano-graphql
@@ -65,8 +65,9 @@ console session freely. See [Docker Compose docs] to tailor for your use-case
 DOCKER_BUILDKIT=1 \
 COMPOSE_DOCKER_CLI_BUILD=1 \
 CHAIN_FOLLOWER_START_SLOT=23068800 \
-CHAIN_FOLLOWER_START_ID=a650a3f398ba4a9427ec8c293e9f7156d81fd2f7ca849014d8d2c1156c359b3a
-</span>docker compose up -d --build &&\
+CHAIN_FOLLOWER_START_ID=a650a3f398ba4a9427ec8c293e9f7156d81fd2f7ca849014d8d2c1156c359b3a \
+RESTORE_SNAPSHOT=https://update-cardano-mainnet.iohk.io/cardano-db-sync/13.4/db-sync-snapshot-schema-13.4-block-10683068-x86_64.tgz \
+docker compose up -d --build &&\
 docker compose logs -f
 ```
 </details>

--- a/README.md
+++ b/README.md
@@ -53,9 +53,14 @@ Choose **one** of the following:
 Boot the [docker compose stack] using a convention for container and volume scoping based on the network, as well as
 optionally hitting the remote cache to speed up the build. The containers are detached, so you can terminate the log
 console session freely. See [Docker Compose docs] to tailor for your use-case
- 
+
+##### Node snapshots
+If you want to speed up the node syncing processes you can use a snapshot. The snapshot is a compressed file that contains the database of a node at a certain block.
+You can download snapshots using Mithril, which are available for mainnet, preprod, and preview networks.
+A detailed explanation can be found [here](https://mithril.network/doc/manual/getting-started/bootstrap-cardano-node)
 <details open>
   <summary><i>mainnet</i></summary>
+Get the most recent weekly snapshot link [here](https://update-cardano-mainnet.iohk.io/cardano-db-sync/index.html#13.4/), and set it as `RESTORE_SNAPSHOT` below, or omit if you wish to sync from genesis.
 
 > **Disclaimer:** The Chainfollower environment variables are currently mandatory.
 > Otherwise the Token registry will get stuck. 
@@ -206,12 +211,6 @@ For other networks:
 ```
 METADATA_SERVER_URI="https://metadata.world.dev.cardano.org"
 ```
-
-### Upgrade Database to Postgres 14
-If you are upgrading from Postgres 11 to 14: A resync will be needed.
-To speed up the process you can use the following snapshots:
-- [DB-Sync](https://update-cardano-mainnet.iohk.io/cardano-db-sync/13.2/db-sync-snapshot-schema-13.2-block-10060706-x86_64.tgz)
-- [Node](https://mithril.network/doc/manual/getting-started/bootstrap-cardano-node)
 
 ### Check Cardano DB sync progress
 Use the GraphQL Playground in the browser at http://localhost:3100/graphql:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,7 @@ services:
   hasura:
     build:
       context: ./packages/api-cardano-db-hasura/hasura
-    image: cardanofoundation/cardano-graphql-hasura:${CARDANO_GRAPHQL_VERSION:-8.2.0}
+    image: cardanofoundation/cardano-graphql-hasura:${CARDANO_GRAPHQL_VERSION:-8.2.1}
     ports:
       - ${HASURA_PORT:-8090}:8080
     depends_on:
@@ -114,7 +114,7 @@ services:
     build:
       context: .
       target: background
-    image: cardanofoundation/cardano-graphql-background:${CARDANO_GRAPHQL_VERSION:-8.2.0}-${NETWORK:-mainnet}
+    image: cardanofoundation/cardano-graphql-background:${CARDANO_GRAPHQL_VERSION:-8.2.1}-${NETWORK:-mainnet}
     depends_on:
       - "hasura"
       - "postgres"
@@ -142,7 +142,7 @@ services:
         - NETWORK=${NETWORK:-mainnet}
       context: .
       target: server
-    image: cardanofoundation/cardano-graphql-server:${CARDANO_GRAPHQL_VERSION:-8.2.0}-${NETWORK:-mainnet}
+    image: cardanofoundation/cardano-graphql-server:${CARDANO_GRAPHQL_VERSION:-8.2.1}-${NETWORK:-mainnet}
     environment:
       - ALLOW_INTROSPECTION=true
       - CACHE_ENABLED=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
 
   cardano-db-sync:
     platform: linux/x86_64
-    image: ghcr.io/intersectmbo/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-13.3.0.0}
+    image: ghcr.io/intersectmbo/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-13.4.0.0}
     command: [
       "--config", "/config/cardano-db-sync/config.json",
       "--socket-path", "/node-ipc/node.socket"
@@ -66,8 +66,11 @@ services:
       - RESTORE_SNAPSHOT=${RESTORE_SNAPSHOT:-}
       - RESTORE_RECREATE_DB=N
     depends_on:
-      - cardano-node
-      - postgres
+      # Depend on both services to be healthy before starting.
+      cardano-node:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
     secrets:
       - postgres_password
       - postgres_user


### PR DESCRIPTION
Upgrading db-sync to 13.4.0.0 this fixes an issue which leads to crashes when trying to sync up using a snapshot

