### PR TITLE
bump cardano-node, db-sync, ogmios versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Check the [releases] for the latest version.
 ``` console
 git clone \
   --single-branch \
-  --branch 8.2.1 \
+  --branch 8.2.2 \
   --recurse-submodules \
   https://github.com/cardano-foundation/cardano-graphql.git \
   && cd cardano-graphql
@@ -60,7 +60,7 @@ You can download snapshots using Mithril, which are available for mainnet, prepr
 A detailed explanation can be found [here](https://mithril.network/doc/manual/getting-started/bootstrap-cardano-node)
 <details open>
   <summary><i>mainnet</i></summary>
-Get the most recent weekly snapshot link [here](https://update-cardano-mainnet.iohk.io/cardano-db-sync/index.html#13.4/), and set it as `RESTORE_SNAPSHOT` below, or omit if you wish to sync from genesis.
+Get the most recent weekly snapshot link [here](https://update-cardano-mainnet.iohk.io/cardano-db-sync/index.html#13.5/), and set it as `RESTORE_SNAPSHOT` below, or omit if you wish to sync from genesis.
 
 > **Disclaimer:** The Chainfollower environment variables are currently mandatory.
 > Otherwise the Token registry will get stuck. 
@@ -71,7 +71,7 @@ DOCKER_BUILDKIT=1 \
 COMPOSE_DOCKER_CLI_BUILD=1 \
 CHAIN_FOLLOWER_START_SLOT=23068800 \
 CHAIN_FOLLOWER_START_ID=a650a3f398ba4a9427ec8c293e9f7156d81fd2f7ca849014d8d2c1156c359b3a \
-RESTORE_SNAPSHOT=https://update-cardano-mainnet.iohk.io/cardano-db-sync/13.4/db-sync-snapshot-schema-13.4-block-10683068-x86_64.tgz \
+RESTORE_SNAPSHOT=https://update-cardano-mainnet.iohk.io/cardano-db-sync/13.5/db-sync-snapshot-schema-13.5-block-10781364-x86_64.tgz \
 docker compose up -d --build &&\
 docker compose logs -f
 ```
@@ -113,6 +113,7 @@ docker compose -p preview logs -f
 
 <details>
   <summary><i>sanchonet</i></summary>
+
 ``` console
 DOCKER_BUILDKIT=1 \
 COMPOSE_DOCKER_CLI_BUILD=1 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
         max-file: "10"
 
   cardano-node:
-    image: ghcr.io/intersectmbo/cardano-node:${CARDANO_NODE_VERSION:-9.1.0}
+    image: ghcr.io/intersectmbo/cardano-node:${CARDANO_NODE_VERSION:-9.1.1}
     environment:
       - NETWORK=${NETWORK:-mainnet}
     volumes:
@@ -36,7 +36,7 @@ services:
     entrypoint: cardano-node run --database-path /node/db --socket-path /ipc/node.socket --topology /config/cardano-node/topology.json --config /config/cardano-node/config.json
     
   ogmios:
-    image: cardanosolutions/ogmios:${OGMIOS_VERSION:-v6.5.0}
+    image: cardanosolutions/ogmios:${OGMIOS_VERSION:-v6.6.0}
     command:
       - --host
       - 0.0.0.0
@@ -55,7 +55,7 @@ services:
 
   cardano-db-sync:
     platform: linux/x86_64
-    image: ghcr.io/intersectmbo/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-13.4.0.0}
+    image: ghcr.io/intersectmbo/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-13.5.0.1}
     command: [
       "--config", "/config/cardano-db-sync/config.json",
       "--socket-path", "/node-ipc/node.socket"
@@ -66,11 +66,11 @@ services:
       - RESTORE_SNAPSHOT=${RESTORE_SNAPSHOT:-}
       - RESTORE_RECREATE_DB=N
     depends_on:
-      # Depend on both services to be healthy before starting.
+      # Depend on both services to be started before starting.
       cardano-node:
-        condition: service_healthy
+        condition: service_started
       postgres:
-        condition: service_healthy
+        condition: service_started
     secrets:
       - postgres_password
       - postgres_user
@@ -90,7 +90,7 @@ services:
   hasura:
     build:
       context: ./packages/api-cardano-db-hasura/hasura
-    image: cardanofoundation/cardano-graphql-hasura:${CARDANO_GRAPHQL_VERSION:-8.2.1}
+    image: cardanofoundation/cardano-graphql-hasura:${CARDANO_GRAPHQL_VERSION:-8.2.2}
     ports:
       - ${HASURA_PORT:-8090}:8080
     depends_on:
@@ -114,7 +114,7 @@ services:
     build:
       context: .
       target: background
-    image: cardanofoundation/cardano-graphql-background:${CARDANO_GRAPHQL_VERSION:-8.2.1}-${NETWORK:-mainnet}
+    image: cardanofoundation/cardano-graphql-background:${CARDANO_GRAPHQL_VERSION:-8.2.2}-${NETWORK:-mainnet}
     depends_on:
       - "hasura"
       - "postgres"
@@ -142,7 +142,7 @@ services:
         - NETWORK=${NETWORK:-mainnet}
       context: .
       target: server
-    image: cardanofoundation/cardano-graphql-server:${CARDANO_GRAPHQL_VERSION:-8.2.1}-${NETWORK:-mainnet}
+    image: cardanofoundation/cardano-graphql-server:${CARDANO_GRAPHQL_VERSION:-8.2.2}-${NETWORK:-mainnet}
     environment:
       - ALLOW_INTROSPECTION=true
       - CACHE_ENABLED=true


### PR DESCRIPTION
# Context
Updating cardano-node version to 9.1.1 (hotfix) and other dependencies

# Important Changes Introduced
- bump cardano-node to v9.1.1;
- bump cardano-db-sync to v13.5.0.1;
- bump ogmios to v6.6.0.
