### PR TITLE
Feat/speed up chainfollower

### DIFF
--- a/packages/api-cardano-db-hasura/src/ChainFollower.ts
+++ b/packages/api-cardano-db-hasura/src/ChainFollower.ts
@@ -64,31 +64,36 @@ export class ChainFollower {
             requestNext()
           },
           rollForward: async ({ block }, requestNext) => {
-            let b
-            switch (block.type) {
-              case 'praos':
-                b = block as BlockPraos
-                break
-              case 'bft':
-                b = block as BlockBFT
-                break
-              case 'ebb': // No transaction in there
-                return
-            }
-            if (b !== undefined && b.transactions !== undefined) {
-              for (const tx of b.transactions) {
-                if (tx.mint !== undefined) {
-                  for (const entry of Object.entries(tx.mint)) {
-                    const policyId = entry[0]
-                    const assetNames = Object.keys(entry[1])
-                    for (const assetName of assetNames) {
-                      await this.saveAsset(policyId, assetName, b)
+            try {
+              let b
+              switch (block.type) {
+                case 'praos':
+                  b = block as BlockPraos
+                  break
+                case 'bft':
+                  b = block as BlockBFT
+                  break
+                case 'ebb': // No transaction in there
+                  return
+              }
+              if (b !== undefined && b.transactions !== undefined) {
+                for (const tx of b.transactions) {
+                  if (tx.mint !== undefined) {
+                    for (const entry of Object.entries(tx.mint)) {
+                      const policyId = entry[0]
+                      const assetNames = Object.keys(entry[1])
+                      for (const assetName of assetNames) {
+                        await this.saveAsset(policyId, assetName, b)
+                      }
                     }
                   }
                 }
               }
+            } catch (e) {
+              console.log(e)
+            } finally {
+              requestNext()
             }
-            requestNext()
           }
         }
       )

--- a/packages/api-cardano-db-hasura/src/ChainFollower.ts
+++ b/packages/api-cardano-db-hasura/src/ChainFollower.ts
@@ -110,12 +110,12 @@ export class ChainFollower {
       policyId
     }
     const response = await this.hasuraClient.insertAssets([asset])
-    console.log(response)
     const SIX_HOURS = 21600
     const THREE_MONTHS = 365
-    if (response && response.length > 0) {
-      const savedAsset = response[0].id
-      await this.queue.publish('asset-metadata-fetch-initial', { savedAsset }, {
+    if (response.insert_assets.affected_rows > 0) {
+      const savedAsset = response.insert_assets.returning[0]
+      const savedAssetId = savedAsset.assetId
+      await this.queue.publish('asset-metadata-fetch-initial', { savedAssetId }, {
         retryDelay: SIX_HOURS,
         retryLimit: THREE_MONTHS
       })

--- a/packages/api-cardano-db-hasura/src/ChainFollower.ts
+++ b/packages/api-cardano-db-hasura/src/ChainFollower.ts
@@ -19,6 +19,8 @@ export class ChainFollower {
   private chainSyncClient: ChainSynchronizationClient
   private queue: PgBoss
   private state: RunnableModuleState
+  private cacheAssets : { assetId: string; assetName: string; firstAppearedInSlot: number; fingerprint: string; policyId: string; }[]
+  private cacheTimer : number
 
   constructor (
     readonly hasuraClient: HasuraBackgroundClient,
@@ -26,6 +28,8 @@ export class ChainFollower {
     private queueConfig: DbConfig
   ) {
     this.state = null
+    this.cacheAssets = []
+    this.cacheTimer = Date.now()
   }
 
   public async initialize (ogmiosConfig: Config['ogmios'], getMostRecentPoint: () => Promise<PointOrOrigin[]>) {
@@ -109,17 +113,36 @@ export class ChainFollower {
       fingerprint: assetFingerprint(policyId, assetName),
       policyId
     }
-    const response = await this.hasuraClient.insertAssets([asset])
-    const SIX_HOURS = 21600
-    const THREE_MONTHS = 365
-    if (response.insert_assets.affected_rows > 0) {
-      const savedAsset = response.insert_assets.returning[0]
-      const savedAssetId = savedAsset.assetId
-      await this.queue.publish('asset-metadata-fetch-initial', { savedAssetId }, {
-        retryDelay: SIX_HOURS,
-        retryLimit: THREE_MONTHS
-      })
+    // introducing a caching to speed things up. The GraphQL insertAssets takes a lot of time.
+    // Saving when > 1000 assets in the cache or every minute
+    this.cacheAssets.push(asset)
+    if (this.cacheAssets.length > 1000 || (Date.now() - this.cacheTimer) / 1000 > 60) {
+      this.cacheTimer = Date.now() // resetting the timer
+      const response = await this.hasuraClient.insertAssets(this.cacheAssets)
+      this.cacheAssets = []
+      if (response.insert_assets.affected_rows > 0) {
+        for (let i = 0; i < response.insert_assets.affected_rows; i++) {
+          const savedAssetId = response.insert_assets.returning[i]
+          const SIX_HOURS = 21600
+          const THREE_MONTHS = 365
+          await this.queue.publish('asset-metadata-fetch-initial', { savedAssetId }, {
+            retryDelay: SIX_HOURS,
+            retryLimit: THREE_MONTHS
+          })
+        }
+      }
     }
+    // const response = await this.hasuraClient.insertAssets([asset])
+    // const SIX_HOURS = 21600
+    // const THREE_MONTHS = 365
+    // if (response.insert_assets.affected_rows > 0) {
+    //   const savedAsset = response.insert_assets.returning[0]
+    //   const savedAssetId = savedAsset.assetId
+    //   await this.queue.publish('asset-metadata-fetch-initial', { savedAssetId }, {
+    //     retryDelay: SIX_HOURS,
+    //     retryLimit: THREE_MONTHS
+    //   })
+    // }
   }
 
   public async start (points: Schema.PointOrOrigin[]) {

--- a/packages/api-cardano-db-hasura/src/ChainFollower.ts
+++ b/packages/api-cardano-db-hasura/src/ChainFollower.ts
@@ -128,7 +128,7 @@ export class ChainFollower {
       response.insert_assets.returning.forEach((asset: { assetId: string }) => {
         const SIX_HOURS = 21600
         const THREE_MONTHS = 365
-        this.queue.publish('asset-metadata-fetch-initial', { assetId: asset.assetId }, {
+        this.queue.publish('asset-metadata-fetch-initial', { assetId: asset.assetId.replace('\\x', '') }, {
           retryDelay: SIX_HOURS,
           retryLimit: THREE_MONTHS
         })

--- a/packages/api-cardano-db-hasura/src/HasuraBackgroundClient.ts
+++ b/packages/api-cardano-db-hasura/src/HasuraBackgroundClient.ts
@@ -258,7 +258,13 @@ export class HasuraBackgroundClient {
     )
     const result = await this.client.request(
       gql`mutation InsertAssets($assets: [Asset_insert_input!]!) {
-          insert_assets(objects: $assets) {
+          insert_assets(
+              objects: $assets,
+              on_conflict: {
+                  constraint: Assets_pkey,
+                  update_columns: []
+              }
+          ) {
               returning {
                   name
                   policyId

--- a/packages/api-cardano-db-hasura/src/HasuraBackgroundClient.ts
+++ b/packages/api-cardano-db-hasura/src/HasuraBackgroundClient.ts
@@ -261,7 +261,7 @@ export class HasuraBackgroundClient {
           insert_assets(
               objects: $assets,
               on_conflict: {
-                  constraint: Assets_pkey,
+                  constraint: Asset_pkey,
                   update_columns: []
               }
           ) {


### PR DESCRIPTION
# Context

The chainfollower took multiple days to sync the assets. This wasn't practically since the time will likely increase in the future. Additionally it was needed to set the starting point of the chainfollower with two environment variables, which was just seen as a work around. 
The problem were:
- The chainfollower got stuck - that's why the custom starting point was needed
- Saving the assets were very slow

This hindered users to use the background easily without days of syncing.

# Proposed Solution

We are saving assets in a local cache and save them batch wise. Additionally I adjusted the `insertAssets` function to skip already existing assets. Through this solution we are able to remove the check `hasAsset` for each asset (which takes a few seconds for every asset)
Additionally catching errors from the Chainfollower and continuing the chainfollower.

This solution increases the speed on mainnet to 10% Assets per hour + removes the need of the custom starting point. 

