### PR TITLE
docs: adding 04 example queries (related to DREP, SPO) to example_queries folder

### DIFF
--- a/packages/api-cardano-db-hasura/src/example_queries/delegation_votes/delegationVotes.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/delegation_votes/delegationVotes.graphql
@@ -1,0 +1,21 @@
+#This query allows to find out which address is delegating votes to which DREP at what epoch.
+query Delegation_Vote (
+  $addr: String
+  $epoch: Int
+) {
+  delegationVotes (where: {address:{_eq:$addr}
+   , transaction:{block:{epoch:{number:{_eq:$epoch}}}}
+  }  ) {
+      address
+      drep  {
+        view
+      }
+    transaction {
+      block  {
+        epochNo
+      }
+      
+    }
+    
+  }
+}

--- a/packages/api-cardano-db-hasura/src/example_queries/delegation_votes/drepInfo.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/delegation_votes/drepInfo.graphql
@@ -1,0 +1,12 @@
+#Look up descriptive information about DREP based on DREP Name
+query dRep_Offchain(
+  $drep_name: String
+){
+    offChainVoteDrepData ( limit: 1, where:{given_name:{_eq:$drep_name}}){
+      motivations
+    	objectives
+    	qualifications 	 
+    
+    }
+    }
+    

--- a/packages/api-cardano-db-hasura/src/example_queries/stake_pools/queryDelegators.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/stake_pools/queryDelegators.graphql
@@ -1,0 +1,14 @@
+# This query is used to find all stake addresses that are delegating to a stake pool (PoolID) at a given EpochNo
+query active_delegators_to_SPO (
+  $poolID: StakePoolID
+  $epochNo: Int
+) {
+  activeStake (
+     where: {
+      stakePoolId: {_eq: $poolID},
+      epoch: {number: {_eq: $epochNo}  }
+    }
+  ) {
+    address
+  }
+}

--- a/packages/api-cardano-db-hasura/src/example_queries/stake_pools/stakePool_ActiveStake.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/stake_pools/stakePool_ActiveStake.graphql
@@ -1,0 +1,16 @@
+# Calculate the total number of active stakes in a stake pool at a given epoch
+query stakePool_activeStake(
+  $poolID: StakePoolID
+  $epochNo: Int
+) {
+   activeStake_aggregate  (where:{
+    epochNo:{_eq:$epochNo}, 
+    stakePoolId:{_eq:$poolID}})
+    {
+          aggregate {
+            	sum {
+                    amount
+                }
+            	 }
+}
+}


### PR DESCRIPTION
# Context

Users, applications may want to query:
- The number of active stake ADA in a pool at a specific epoch
- How many delegators are delegating to a specific stake pool.
- Which dRep is the stake address being delegated to?
- Look up information about a dRep based on dRep name

# Proposed Solution
Create 04 queries corresponding to the 04  needs above

# Important Changes Introduced
No
